### PR TITLE
fbfw-49 typography theme added

### DIFF
--- a/beta-src/src/App.tsx
+++ b/beta-src/src/App.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import "./assets/css/App.css";
-import { Box } from "@mui/material";
+import Box from "@mui/material/Box";
 import map from "./assets/svg/map.svg";
 
 const App: React.FC = function (): React.ReactElement {

--- a/beta-src/src/App.tsx
+++ b/beta-src/src/App.tsx
@@ -1,12 +1,26 @@
 import * as React from "react";
 import "./assets/css/App.css";
-import Box from "@mui/material/Box";
-import map from "./assets/svg/map.svg";
+import { Box, Typography } from "@mui/material";
+// import map from "./assets/svg/map.svg"; <img alt="Game Map" src={map} />
 
 const App: React.FC = function (): React.ReactElement {
   return (
     <Box className="App">
-      <img alt="Game Map" src={map} />
+      <Typography gutterBottom variant="h1">
+        variant h1, figma h1
+      </Typography>
+      <Typography gutterBottom variant="h2">
+        variant h2, figma h2
+      </Typography>
+      <Typography gutterBottom variant="h3">
+        variant h3, figma h3
+      </Typography>
+      <Typography gutterBottom variant="body1">
+        variant body1 (default), figma p
+      </Typography>
+      <Typography gutterBottom variant="smallLabel" component="label">
+        variant smallLabel, figma small label
+      </Typography>
     </Box>
   );
 };

--- a/beta-src/src/App.tsx
+++ b/beta-src/src/App.tsx
@@ -1,26 +1,12 @@
 import * as React from "react";
 import "./assets/css/App.css";
-import { Box, Typography } from "@mui/material";
-// import map from "./assets/svg/map.svg"; <img alt="Game Map" src={map} />
+import { Box } from "@mui/material";
+import map from "./assets/svg/map.svg";
 
 const App: React.FC = function (): React.ReactElement {
   return (
     <Box className="App">
-      <Typography gutterBottom variant="h1">
-        variant h1, figma h1
-      </Typography>
-      <Typography gutterBottom variant="h2">
-        variant h2, figma h2
-      </Typography>
-      <Typography gutterBottom variant="h3">
-        variant h3, figma h3
-      </Typography>
-      <Typography gutterBottom variant="body1">
-        variant body1 (default), figma p
-      </Typography>
-      <Typography gutterBottom variant="smallLabel" component="label">
-        variant smallLabel, figma small label
-      </Typography>
+      <img alt="Game Map" src={map} />
     </Box>
   );
 };

--- a/beta-src/src/webDiplomacyTheme.ts
+++ b/beta-src/src/webDiplomacyTheme.ts
@@ -14,17 +14,17 @@ declare module "@mui/material/styles" {
   }
 
   interface TypographyVariants {
-    smallLabel: React.CSSProperties;
+    label: React.CSSProperties;
   }
 
   export interface TypographyVariantsOptions {
-    smallLabel?: React.CSSProperties;
+    label?: React.CSSProperties;
   }
 }
 
 declare module "@mui/material/Typography" {
   interface TypographyPropsVariantOverrides {
-    smallLabel: true;
+    label: true;
   }
 }
 
@@ -51,32 +51,37 @@ const webDiplomacyTheme = createTheme({
       contrastText: "#000",
     },
   },
-  typography: {
-    body1: {
-      fontSize: 14,
-      lineHeight: 1.29,
-    },
-    h1: {
-      fontSize: 20,
-      fontWeight: 700,
-      lineHeight: 1.2,
-    },
-    h2: {
-      fontSize: 16,
-      fontWeight: 700,
-      lineHeight: 1.125,
-    },
-    h3: {
-      fontSize: 14,
-      fontWeight: 700,
-      lineHeight: 1.15,
-    },
-    smallLabel: {
-      fontSize: 10,
-      fontWeight: 400,
-      lineHeight: 1,
-    },
-  },
 });
+
+webDiplomacyTheme.typography.body1 = {
+  fontFamily: webDiplomacyTheme.typography.fontFamily,
+  fontSize: 14,
+  fontWeight: 400,
+  lineHeight: 1.2,
+};
+
+webDiplomacyTheme.typography.h1 = {
+  fontFamily: webDiplomacyTheme.typography.fontFamily,
+  fontSize: 16,
+  fontWeight: 700,
+  lineHeight: 1.2,
+  [webDiplomacyTheme.breakpoints.up("desktop")]: {
+    fontSize: 20,
+  },
+};
+
+webDiplomacyTheme.typography.h2 = {
+  fontFamily: webDiplomacyTheme.typography.fontFamily,
+  fontSize: 14,
+  fontWeight: 700,
+  lineHeight: 1.2,
+};
+
+webDiplomacyTheme.typography.label = {
+  fontFamily: webDiplomacyTheme.typography.fontFamily,
+  fontSize: 10,
+  fontWeight: 400,
+  lineHeight: 1,
+};
 
 export default webDiplomacyTheme;

--- a/beta-src/src/webDiplomacyTheme.ts
+++ b/beta-src/src/webDiplomacyTheme.ts
@@ -1,13 +1,40 @@
 import { createTheme } from "@mui/material/styles";
 
+declare module "@mui/material/styles" {
+  interface BreakpointOverrides {
+    xs: false;
+    sm: false;
+    md: false;
+    lg: false;
+    xl: false;
+    mobile: true;
+    mobileLg: true;
+    tablet: true;
+    desktop: true;
+  }
+
+  interface TypographyVariants {
+    smallLabel: React.CSSProperties;
+  }
+
+  export interface TypographyVariantsOptions {
+    smallLabel?: React.CSSProperties;
+  }
+}
+
+declare module "@mui/material/Typography" {
+  interface TypographyPropsVariantOverrides {
+    smallLabel: true;
+  }
+}
+
 const webDiplomacyTheme = createTheme({
   breakpoints: {
     values: {
-      xs: 0,
-      sm: 414,
-      md: 834,
-      lg: 1200,
-      xl: 1500,
+      mobile: 0,
+      mobileLg: 414,
+      tablet: 834,
+      desktop: 1500,
     },
   },
   palette: {
@@ -25,7 +52,30 @@ const webDiplomacyTheme = createTheme({
     },
   },
   typography: {
-    fontFamily: "SF Pro Display, Segoe UI, Droid Sans, sans-serif",
+    body1: {
+      fontSize: 14,
+      lineHeight: 1.29,
+    },
+    h1: {
+      fontSize: 20,
+      fontWeight: 700,
+      lineHeight: 1.2,
+    },
+    h2: {
+      fontSize: 16,
+      fontWeight: 700,
+      lineHeight: 1.125,
+    },
+    h3: {
+      fontSize: 14,
+      fontWeight: 700,
+      lineHeight: 1.15,
+    },
+    smallLabel: {
+      fontSize: 10,
+      fontWeight: 400,
+      lineHeight: 1,
+    },
   },
 });
 


### PR DESCRIPTION
this PR adds typography to the existing theme based on the requirements in the figma:

https://www.figma.com/file/JnpO52R22kG3lB2wexs9rB/webDiplomacy?node-id=3098%3A43212

![Screen Shot 2022-01-27 at 2 32 16 PM](https://user-images.githubusercontent.com/37419695/151454500-4a09ff24-4f55-4e61-ae7d-638dc3cb1718.png)

with this change the mui typography component can be used as follows:

```
import { ... , Typography } from "@mui/material";
...
<Typography variant="h1">
  variant h1, figma h1
</Typography>
<Typography variant="h2">
  variant h2, figma h2
</Typography>
<Typography variant="body1">
  variant body1 (default), figma p
</Typography>
<Typography variant="label">
  variant label, figma label
</Typography>
```

for h1, h2, use variant="h1" or h2.

for a paragraph, use body1 as the variant.

for a span, use label as a variant.

here is what the resulting markup looks like:

![Screen Shot 2022-01-27 at 2 27 27 PM](https://user-images.githubusercontent.com/37419695/151454994-3d31a1ce-4f27-4c5b-b594-10c011aec5c4.png)

note that the resulting markup can be changed if needed. for example, if you want to use the body1 variant but want a div instead of a p you can do:

```
<Typography component="div" variant="body1">
  variant body1 (default), figma p...but will be a div in markup because component="div"
</Typography>
```

screenshots of results:
===

![Screen Shot 2022-01-27 at 2 27 47 PM](https://user-images.githubusercontent.com/37419695/151455263-153d6222-9746-43e3-9385-a34d033c56c6.png)
![Screen Shot 2022-01-27 at 2 27 41 PM](https://user-images.githubusercontent.com/37419695/151455268-9a8363b6-e7e5-4867-923b-fd9aee074bc6.png)
![Screen Shot 2022-01-27 at 2 27 34 PM](https://user-images.githubusercontent.com/37419695/151455273-24f6e217-fc5e-4735-9f15-4ec3e62351d4.png)
![Screen Shot 2022-01-27 at 2 27 27 PM](https://user-images.githubusercontent.com/37419695/151455277-02b57029-e120-494f-90db-d90aeed32e40.png)

