### PR TITLE
fbfw-48 game board button component

### DIFF
--- a/beta-src/src/App.tsx
+++ b/beta-src/src/App.tsx
@@ -1,26 +1,17 @@
 import * as React from "react";
 import "./assets/css/App.css";
 import { Box, Button } from "@mui/material";
-import { useState } from "react";
 // import map from "./assets/svg/map.svg"; <img alt="Game Map" src={map} />
 
 const App: React.FC = function (): React.ReactElement {
-  const [isDisabled, setIsDisabled] = useState(false);
   return (
     <Box className="App">
-      <Button
-        disabled={isDisabled}
-        onClick={() => setIsDisabled(!isDisabled)}
-        variant="contained"
-      >
-        Save
-      </Button>
-      <Button
-        color="secondary"
-        onClick={() => setIsDisabled(!isDisabled)}
-        variant="contained"
-      >
+      <Button variant="contained">Save</Button>
+      <Button color="secondary" variant="contained">
         Cancel
+      </Button>
+      <Button disabled variant="contained">
+        Save
       </Button>
     </Box>
   );

--- a/beta-src/src/App.tsx
+++ b/beta-src/src/App.tsx
@@ -1,18 +1,28 @@
 import * as React from "react";
 import "./assets/css/App.css";
-import { Box, Button } from "@mui/material";
+import Box from "@mui/material/Box";
+import WDButton from "./wd-button/WDButton";
 // import map from "./assets/svg/map.svg"; <img alt="Game Map" src={map} />
 
 const App: React.FC = function (): React.ReactElement {
+  const whatAmI = (e) => alert(e.target.innerText);
   return (
-    <Box className="App">
-      <Button variant="contained">Save</Button>
-      <Button color="secondary" variant="contained">
-        Cancel
-      </Button>
-      <Button disabled variant="contained">
-        Save
-      </Button>
+    <Box
+      className="App"
+      m={5}
+      style={{
+        display: "flex",
+        justifyContent: "space-between",
+      }}
+    >
+      <WDButton onClick={whatAmI}>primary</WDButton>
+      <WDButton color="secondary" onClick={whatAmI}>
+        secondary
+      </WDButton>
+      <WDButton disabled>primary disabled</WDButton>
+      <WDButton color="secondary" disabled>
+        secondary disabled
+      </WDButton>
     </Box>
   );
 };

--- a/beta-src/src/App.tsx
+++ b/beta-src/src/App.tsx
@@ -1,12 +1,27 @@
 import * as React from "react";
 import "./assets/css/App.css";
-import Box from "@mui/material/Box";
-import map from "./assets/svg/map.svg";
+import { Box, Button } from "@mui/material";
+import { useState } from "react";
+// import map from "./assets/svg/map.svg"; <img alt="Game Map" src={map} />
 
 const App: React.FC = function (): React.ReactElement {
+  const [isDisabled, setIsDisabled] = useState(false);
   return (
     <Box className="App">
-      <img alt="Game Map" src={map} />
+      <Button
+        disabled={isDisabled}
+        onClick={() => setIsDisabled(!isDisabled)}
+        variant="contained"
+      >
+        Save
+      </Button>
+      <Button
+        color="secondary"
+        onClick={() => setIsDisabled(!isDisabled)}
+        variant="contained"
+      >
+        Cancel
+      </Button>
     </Box>
   );
 };

--- a/beta-src/src/App.tsx
+++ b/beta-src/src/App.tsx
@@ -1,28 +1,12 @@
 import * as React from "react";
 import "./assets/css/App.css";
 import Box from "@mui/material/Box";
-import WDButton from "./wd-button/WDButton";
-// import map from "./assets/svg/map.svg"; <img alt="Game Map" src={map} />
+import map from "./assets/svg/map.svg";
 
 const App: React.FC = function (): React.ReactElement {
-  const whatAmI = (e) => alert(e.target.innerText);
   return (
-    <Box
-      className="App"
-      m={5}
-      style={{
-        display: "flex",
-        justifyContent: "space-between",
-      }}
-    >
-      <WDButton onClick={whatAmI}>primary</WDButton>
-      <WDButton color="secondary" onClick={whatAmI}>
-        secondary
-      </WDButton>
-      <WDButton disabled>primary disabled</WDButton>
-      <WDButton color="secondary" disabled>
-        secondary disabled
-      </WDButton>
+    <Box className="App">
+      <img alt="Game Map" src={map} />
     </Box>
   );
 };

--- a/beta-src/src/wd-button/WDButton.tsx
+++ b/beta-src/src/wd-button/WDButton.tsx
@@ -1,0 +1,35 @@
+import * as React from "react";
+import Button from "@mui/material/Button";
+
+interface WDButtonProps {
+  children: React.ReactNode;
+  color?: "primary" | "secondary";
+  disabled?: boolean;
+  onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+const WDButton: React.FC<WDButtonProps> = function ({
+  children,
+  color,
+  disabled,
+  onClick,
+}): React.ReactElement {
+  return (
+    <Button
+      color={color}
+      disabled={disabled}
+      onClick={onClick && onClick}
+      variant="contained"
+    >
+      {children}
+    </Button>
+  );
+};
+
+WDButton.defaultProps = {
+  color: "primary",
+  disabled: false,
+  onClick: undefined,
+};
+
+export default WDButton;

--- a/beta-src/src/webDiplomacyTheme.ts
+++ b/beta-src/src/webDiplomacyTheme.ts
@@ -41,7 +41,6 @@ const webDiplomacyTheme = createTheme({
       lineHeight: 1.2,
       textTransform: "none",
     },
-    fontFamily: "SF Pro Display, Segoe UI, Droid Sans, sans-serif",
   },
 });
 

--- a/beta-src/src/webDiplomacyTheme.ts
+++ b/beta-src/src/webDiplomacyTheme.ts
@@ -34,9 +34,16 @@ declare module "@mui/material/Typography" {
  * define constants that are to be re-used in the theme. use generic names that
  * describe their usage.
  */
+const activeButtonStyle = {
+  backgroundColor: "#fff",
+  boxShadow: "0 0 2px 2px #000",
+  color: "#000",
+};
 const boldFontWeight = 700;
-const disabledBackground = "rgba(0, 0, 0, 0.25)";
-const disabledText = "rgba(255, 255, 255, 0.25)";
+const disabledBackground = "#b8b8b8";
+const disabledText = "#cacaca";
+const disabledBackgroundSecondary = "transparent";
+const disabledTextSecondary = "#bababa";
 const defaultLineHeight = 1.2;
 const normalFontWeight = 400;
 
@@ -60,13 +67,30 @@ const webDiplomacyTheme = createTheme({
           padding: "10px 18px",
         },
         containedPrimary: {
+          "&:active": {
+            ...activeButtonStyle,
+          },
+          "&:focus": {
+            ...activeButtonStyle,
+          },
           "&:hover": {
-            backgroundColor: "#ff00ff",
+            backgroundColor: "#757575",
+            color: "#fff",
           },
         },
         containedSecondary: {
+          "&.Mui-disabled": {
+            backgroundColor: disabledBackgroundSecondary,
+            color: disabledTextSecondary,
+          },
+          "&:active": {
+            ...activeButtonStyle,
+          },
+          "&:focus": {
+            ...activeButtonStyle,
+          },
           "&:hover": {
-            backgroundColor: "#ff00ff",
+            backgroundColor: "#fafafa",
           },
         },
       },

--- a/beta-src/src/webDiplomacyTheme.ts
+++ b/beta-src/src/webDiplomacyTheme.ts
@@ -30,6 +30,8 @@ declare module "@mui/material/Typography" {
 
 // define re-used constants
 const boldFontWeight = 700;
+const disabledBackground = "rgba(0, 0, 0, 0.25)";
+const disabledText = "rgba(255, 255, 255, 0.25)";
 const defaultLineHeight = 1.2;
 const normalFontWeight = 400;
 
@@ -50,10 +52,24 @@ const webDiplomacyTheme = createTheme({
           borderRadius: 18,
           padding: "10px 18px",
         },
+        containedPrimary: {
+          "&:hover": {
+            backgroundColor: "#ff00ff",
+          },
+        },
+        containedSecondary: {
+          "&:hover": {
+            backgroundColor: "#ff00ff",
+          },
+        },
       },
     },
   },
   palette: {
+    action: {
+      disabledBackground,
+      disabled: disabledText,
+    },
     error: {
       main: "#f00",
       contrastText: "#fff",
@@ -70,8 +86,8 @@ const webDiplomacyTheme = createTheme({
   typography: {
     button: {
       fontSize: 12,
-      fontWeight: 700,
-      lineHeight: 1.2,
+      fontWeight: boldFontWeight,
+      lineHeight: defaultLineHeight,
       textTransform: "none",
     },
   },

--- a/beta-src/src/webDiplomacyTheme.ts
+++ b/beta-src/src/webDiplomacyTheme.ts
@@ -42,7 +42,7 @@ const webDiplomacyTheme = createTheme({
       styleOverrides: {
         root: {
           borderRadius: 18,
-          padding: "10px 18px 12px",
+          padding: "10px 18px",
         },
       },
     },

--- a/beta-src/src/webDiplomacyTheme.ts
+++ b/beta-src/src/webDiplomacyTheme.ts
@@ -10,6 +10,16 @@ const webDiplomacyTheme = createTheme({
       xl: 1500,
     },
   },
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: 18,
+          padding: "10px 18px 12px",
+        },
+      },
+    },
+  },
   palette: {
     error: {
       main: "#f00",
@@ -25,6 +35,12 @@ const webDiplomacyTheme = createTheme({
     },
   },
   typography: {
+    button: {
+      fontSize: 12,
+      fontWeight: 700,
+      lineHeight: 1.2,
+      textTransform: "none",
+    },
     fontFamily: "SF Pro Display, Segoe UI, Droid Sans, sans-serif",
   },
 });


### PR DESCRIPTION
this diff creates a wrapper component, WDButton, for the MUI Button component. also, it adds CSS theming so that buttons in the project match the figma specs found here:

https://www.figma.com/file/JnpO52R22kG3lB2wexs9rB/webDiplomacy?node-id=3132%3A43493

figma:
---
![Screen Shot 2022-01-31 at 11 15 13 AM](https://user-images.githubusercontent.com/37419695/151860724-2f100e79-c1ce-4626-bb57-7930d435aa6b.png)

example markup for each button:
---
```
const logText = (event) => alert(event.target.innerText);
return(
  <WDButton onClick={logText}>primary</WDButton>
  <WDButton color="secondary" onClick={logText}>
    secondary
  </WDButton>
  <WDButton disabled>primary disabled</WDButton>
  <WDButton color="secondary" disabled>
    secondary disabled
  </WDButton>
);
```

this diff:
---
![Screen Shot 2022-01-31 at 11 40 07 AM](https://user-images.githubusercontent.com/37419695/151861135-13d7e25e-0e19-4fbc-bbf0-45debcf83586.png)

keyboard, mouse, hover, active, focus functionality:
---

https://user-images.githubusercontent.com/37419695/151864122-1ab6c665-e7bd-44d9-8270-efd98f6644eb.mov


