### PR TITLE
change onClick and onClose handler types and make onClose for Popover optional

### DIFF
--- a/beta-src/src/components/WDButton.tsx
+++ b/beta-src/src/components/WDButton.tsx
@@ -5,7 +5,7 @@ interface WDButtonProps {
   children: React.ReactNode;
   color?: "primary" | "secondary";
   disabled?: boolean;
-  onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  onClick?: React.MouseEventHandler<HTMLButtonElement> | undefined;
 }
 
 const WDButton: React.FC<WDButtonProps> = function ({

--- a/beta-src/src/components/WDPopover.tsx
+++ b/beta-src/src/components/WDPopover.tsx
@@ -1,14 +1,16 @@
 import * as React from "react";
 import { useRef } from "react";
-import { Box, Popover } from "@mui/material";
+import { Box, ModalProps, Popover } from "@mui/material";
 
 interface WDPopoverProps {
   children: React.ReactNode;
   isOpen: boolean;
   /**
-   * A callback to be used when the popover closes. Must contain setIsOpen(false) inside of onClose when declared and passed from parent
+   * A optional callback to be called when the Popover closes. For example:
+   *
+   * () => setIsOpen(false)
    */
-  onClose: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  onClose?: ModalProps["onClose"];
   /**
    * A component that opens or closes the Popover when clicked.
    */
@@ -30,10 +32,10 @@ const WDPopover: React.FC<WDPopoverProps> = function ({
       }}
     >
       <Box
+        ref={anchorEl}
         sx={{
           pt: "15px",
         }}
-        ref={anchorEl}
       >
         {popoverTrigger}
       </Box>
@@ -86,6 +88,10 @@ const WDPopover: React.FC<WDPopoverProps> = function ({
       </Popover>
     </Box>
   );
+};
+
+WDPopover.defaultProps = {
+  onClose: undefined,
 };
 
 export default WDPopover;


### PR DESCRIPTION
this PR makes the onClick typescript type match the MUI Button onClick type. also, the MUI Popover onClose type is used for WDPopover. the onClose callback is now optional.