### PR TITLE
updated WDMap to forward ref

### DIFF
--- a/beta-src/src/components/map/WDMap.tsx
+++ b/beta-src/src/components/map/WDMap.tsx
@@ -5,14 +5,10 @@ import WDGameBoardOutlines from "./variants/classic/components/WDGameBoardOutlin
 import WDNeutral from "./variants/classic/components/WDNeutral";
 import WDSeaAreas from "./variants/classic/components/WDSeaAreas";
 
-interface WDMapElement {
-  ref: React.RefObject<SVGSVGElement>;
-}
-
 const WDMap: React.ForwardRefExoticComponent<
   React.RefAttributes<SVGSVGElement>
-> = React.forwardRef<SVGSVGElement>(function (_props, ref): React.ReactElement {
-  return (
+> = React.forwardRef(
+  (_props, ref): React.ReactElement => (
     <svg
       fill="none"
       ref={ref}
@@ -66,7 +62,7 @@ const WDMap: React.ForwardRefExoticComponent<
         </clipPath>
       </defs>
     </svg>
-  );
-});
+  ),
+);
 
 export default React.memo(WDMap);

--- a/beta-src/src/components/map/WDMap.tsx
+++ b/beta-src/src/components/map/WDMap.tsx
@@ -5,17 +5,17 @@ import WDGameBoardOutlines from "./variants/classic/components/WDGameBoardOutlin
 import WDNeutral from "./variants/classic/components/WDNeutral";
 import WDSeaAreas from "./variants/classic/components/WDSeaAreas";
 
-interface WDMapProps {
-  svgElement: any;
+interface WDMapElement {
+  ref: React.RefObject<SVGSVGElement>;
 }
 
-const WDMap: React.FC<WDMapProps> = function ({
-  svgElement,
-}): React.ReactElement {
+const WDMap: React.ForwardRefExoticComponent<
+  React.RefAttributes<SVGSVGElement>
+> = React.forwardRef<SVGSVGElement>(function (_props, ref): React.ReactElement {
   return (
     <svg
       fill="none"
-      ref={svgElement}
+      ref={ref}
       style={{
         width: "100%",
         height: "100%",
@@ -67,6 +67,6 @@ const WDMap: React.FC<WDMapProps> = function ({
       </defs>
     </svg>
   );
-};
+});
 
 export default React.memo(WDMap);

--- a/beta-src/src/components/map/WDMapController.tsx
+++ b/beta-src/src/components/map/WDMapController.tsx
@@ -32,7 +32,7 @@ const WDMapController: React.FC<WDMapControllerProps> = function ({
   device,
   viewport,
 }): React.ReactElement {
-  const svgElement = React.useRef(null);
+  const svgElement = React.useRef<SVGSVGElement>(null);
   const [scaleMin, scaleMax] = getInitialScaleForDevice(device);
 
   React.useLayoutEffect(() => {
@@ -76,7 +76,7 @@ const WDMapController: React.FC<WDMapControllerProps> = function ({
         height: viewport.height,
       }}
     >
-      <WDMap svgElement={svgElement} />
+      <WDMap ref={svgElement} />
     </div>
   );
 };


### PR DESCRIPTION
previously we were passing a type of `any` to `WDMap` for the ref being used in `WDMapController`. this diff implements forward ref with strong typing to replace `any`

testing:
===
confirmed warning is removed from build and map functions as expected

before:
===
![Screen Shot 2022-02-16 at 3 23 31 PM](https://user-images.githubusercontent.com/37419695/154374367-34516cc8-9dee-4085-9f75-ada680f1e95d.png)
---
after:
===
![Screen Shot 2022-02-16 at 3 20 44 PM](https://user-images.githubusercontent.com/37419695/154374138-3aba07f8-074b-48db-a81f-13d8485e6718.png)
.